### PR TITLE
Removed reference to HTTPContext

### DIFF
--- a/ELMAH Appender for log4net/ELMAHAppender.cs
+++ b/ELMAH Appender for log4net/ELMAHAppender.cs
@@ -21,7 +21,7 @@ namespace elmahappender_log4net
 			_HostName = Environment.MachineName;
 			try
 			{
-				this._ErrorLog = ErrorLog.GetDefault(HttpContext.Current);
+				this._ErrorLog = ErrorLog.GetDefault(null);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Removed the reference to HTTPContext so that the Log4Net configurator can be called from the Global.asax to support MVC projects
