### PR TITLE
Better alignment with LoggingEvent

### DIFF
--- a/ELMAH Appender for log4net 1.2.10/ELMAH Appender for log4net 1.2.10.csproj
+++ b/ELMAH Appender for log4net 1.2.10/ELMAH Appender for log4net 1.2.10.csproj
@@ -36,16 +36,11 @@
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/ELMAH Appender for log4net 1.2.10/ELMAH Appender for log4net 1.2.10.csproj
+++ b/ELMAH Appender for log4net 1.2.10/ELMAH Appender for log4net 1.2.10.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>elmahappender_log4net</RootNamespace>
     <AssemblyName>elmahappender_log4net</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elmah">

--- a/ELMAH Appender for log4net 1.2.10/packages.config
+++ b/ELMAH Appender for log4net 1.2.10/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
 </packages>

--- a/ELMAH Appender for log4net 1.2.10/packages.config
+++ b/ELMAH Appender for log4net 1.2.10/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
-  <package id="log4net" version="1.2.10" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net20" />
 </packages>

--- a/ELMAH Appender for log4net/ELMAHAppender.cs
+++ b/ELMAH Appender for log4net/ELMAHAppender.cs
@@ -1,65 +1,62 @@
 ﻿using Elmah;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Web;
 
-namespace elmahappender_log4net
+namespace Hsb.Log4Net.Appender
 {
-	public class ELMAHAppender : log4net.Appender.AppenderSkeleton
-	{
-		private readonly static Type _DeclaringType = typeof(ELMAHAppender);
-		private string _HostName;
-		private ErrorLog _ErrorLog;
+    public class ELMAHAppender : log4net.Appender.AppenderSkeleton
+    {
+        private string _HostName;
+        private ErrorLog _ErrorLog;
 
-		public bool UseNullContext { get; set; }
+        public bool UseNullContext { get; set; }
 
-		public override void ActivateOptions()
-		{
-			base.ActivateOptions();
-			_HostName = Environment.MachineName;
-			try
-			{
-				if (UseNullContext)
-				{
-					this._ErrorLog = ErrorLog.GetDefault(null);
-				}
-				else
-				{
-					this._ErrorLog = ErrorLog.GetDefault(HttpContext.Current);
-				}
-			}
-			catch (Exception ex)
-			{
-				this.ErrorHandler.Error("Could not create default ELMAH error log", ex);
-			}
-		}
+        public override void ActivateOptions()
+        {
+            base.ActivateOptions();
+            _HostName = Environment.MachineName;
+            try
+            {
+                if (UseNullContext)
+                {
+                    this._ErrorLog = ErrorLog.GetDefault(null);
+                }
+                else
+                {
+                    this._ErrorLog = ErrorLog.GetDefault(HttpContext.Current);
+                }
+            }
+            catch (Exception ex)
+            {
+                this.ErrorHandler.Error("Could not create default ELMAH error log", ex);
+            }
+        }
 
-
-		protected override void Append(log4net.Core.LoggingEvent loggingEvent)
-		{
-			if (this._ErrorLog != null)
-			{
-				Error error;
-				if (loggingEvent.ExceptionObject != null)
-				{
-					error = new Error(loggingEvent.ExceptionObject);
-				}
-				else
-				{
-					error = new Error();
-				}
-				error.Time = DateTime.Now;
-				if (loggingEvent.MessageObject != null)
-				{
-					error.Message = loggingEvent.MessageObject.ToString();
-				}
-				error.Detail = base.RenderLoggingEvent(loggingEvent);
-				error.HostName = this._HostName;
-				error.User = loggingEvent.Identity;
-				error.Type = "log4net - " + loggingEvent.Level; // maybe allow the type to be customized?
-				this._ErrorLog.Log(error);
-			}
-		}
-	}
+        protected override void Append(log4net.Core.LoggingEvent loggingEvent)
+        {
+            if (this._ErrorLog != null)
+            {
+                Error error;
+                if (loggingEvent.ExceptionObject != null)
+                {
+                    error = new Error(loggingEvent.ExceptionObject);
+                }
+                else
+                {
+                    error = new Error();
+                }
+                error.Time = loggingEvent.TimeStamp;
+                if (loggingEvent.MessageObject != null)
+                {
+                    error.Message = loggingEvent.MessageObject.ToString();
+                }
+                error.Detail = base.RenderLoggingEvent(loggingEvent);
+                error.HostName = this._HostName;
+                error.User = loggingEvent.Identity;
+                error.Source = loggingEvent.LoggerName;
+                error.Type = loggingEvent.Level.Name;
+                this._ErrorLog.Log(error);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I thought it would be more aligned with Log4Net filtering if the source property were set to the LoggerName (commonly implemented as the declaring type where the logger is called).

Additionally, the time should be the time from the logging event.
Type set to the logger level (since source contains the LoggerName)
Removed unused static declaration.
Updated for Log4Net Nuget Reference.
Clean up not found assembly references in the 1.2.10 project.
Clean up unused using statements.
Target .NET 4.5 consistently in the 1.2.10 project
